### PR TITLE
TwoGtp: Flip players in SGF files on alternate games

### DIFF
--- a/src/net/sf/gogui/tools/twogtp/TwoGtp.java
+++ b/src/net/sf/gogui/tools/twogtp/TwoGtp.java
@@ -516,6 +516,14 @@ public class TwoGtp
         String whiteCommand = m_white.getProgramCommand();
         String blackVersion = m_black.getVersion();
         String whiteVersion = m_white.getVersion();
+        if (isAlternated()) {
+          nameBlack = m_white.getLabel();
+          nameWhite = m_black.getLabel();
+          blackCommand = m_white.getProgramCommand();
+          whiteCommand = m_black.getProgramCommand();
+          blackVersion = m_white.getVersion();
+          whiteVersion = m_black.getVersion();
+        }
         m_game.setPlayer(BLACK, nameBlack);
         m_game.setPlayer(WHITE, nameWhite);
         if (m_referee != null)
@@ -538,9 +546,9 @@ public class TwoGtp
             comment.append(m_openingFile);
         }
         comment.append("\nResult[Black]: ");
-        comment.append(resultBlack);
+        comment.append(isAlternated() ? resultWhite : resultBlack);
         comment.append("\nResult[White]: ");
-        comment.append(resultWhite);
+        comment.append(isAlternated() ? resultBlack : resultWhite);
         if (m_referee != null)
         {
             comment.append("\nReferee: ");


### PR DESCRIPTION
## Context

Issue: #9 

When `gogui-twogtp -black <player1> -white <player2>` is run with the `-alternate` flag, odd-indexed games are played with `<player1>` and `<player2>` flipped. However, the contents of `PB[]` and `PW[]` are not flipped.

For example, here are the SGFs from `gogui-twogtp -black <Leela> -white <KataGo> -games 2 -alternate`, in which KataGo (playing random moves) loses both games:

`game-0.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-05]
C[Black command: docker attach e6bdb46d6c657465f4fa7754ff83791de50e08776ee6b930fb3fd61da2b75954
White command: docker attach 066da9ac0f1b51bc1a5ad41cdc57d5c53c50c5620a408fa68b908c2e20f5b238
Black version: 0.17
White version: 1.10.0
Result[Black\]: B+211.5
Result[White\]: B+254.5
Host: b0126f247630 (AMD EPYC 7763 64-Core Processor)
Date: October 5, 2022 at 1:33:43 AM UTC]
;B[dp];W[dc];B[pp];W[jm];B[qd];W[qp];B[qq];W[rs];B[qo];W[dr]
...
```
`game-1.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-05]
C[Black command: docker attach e6bdb46d6c657465f4fa7754ff83791de50e08776ee6b930fb3fd61da2b75954
White command: docker attach 066da9ac0f1b51bc1a5ad41cdc57d5c53c50c5620a408fa68b908c2e20f5b238
Black version: 0.17
White version: 1.10.0
Result[Black\]: W+321.5
Result[White\]: W+358.5
Host: b0126f247630 (AMD EPYC 7763 64-Core Processor)
Date: October 5, 2022 at 2:33:53 AM UTC]
;B[qd];W[dd];B[op];W[dp];B[oa];W[qq];B[se];W[po];B[af];W[pc]
...
```
In `game-1.sgf`, KataGo is playing as black, but `PB[]`, `PW[]`, and `C[]` do not reflect that. If `game-1.sgf` is viewed as a standalone SGF file, this is incorrect.

## Changes

* Flip `PB[]`, `PW[]`, and the contents of `C[]` on alternate games

## Testing

Ran `gogui-twogtp -black <Leela> -white <KataGo> -games 2 -alternate`. Resulting SGF files:
`game-0.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-09]
C[Black command: nc leela 80
White command: nc katago 80
Black version: 0.17
White version: 1.10.0
Result[Black\]: B+143.5
Result[White\]: B+146.5
Host: 26299f676194 (AMD EPYC 7763 64-Core Processor)
Date: October 9, 2022 at 6:59:12 PM UTC]
;B[dc];W[qa];B[pq];W[fb];B[qc];W[om];B[oc];W[da];B[dp];W[ll]
...
```
`game-1.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[KataGo]PW[Leela Zero]DT[2022-10-09]RE[W+6.5]
C[Black command: nc katago 80
White command: nc leela 80
Black version: 1.10.0
White version: 0.17
Result[Black\]: W+6.5
Result[White\]: W+6.5
Host: 26299f676194 (AMD EPYC 7763 64-Core Processor)
Date: October 9, 2022 at 6:59:13 PM UTC]
;B[mh];W[pp];B[lj];W[cd];B[an];W[cp];B[qs];W[pc];B[cn];W[eq]
...
```
`game.dat`: (The behavior here is unchanged—the scores are all relative to the original `-black` and `-white` args) 
```
# Black: Leela Zero
# BlackCommand: nc leela 80
# BlackLabel: Leela Zero
# BlackVersion: 0.17
# Date: October 9, 2022 at 6:59:07 PM UTC
# Host: 26299f676194 (AMD EPYC 7763 64-Core Processor)
# Komi: 6.5
# Referee: -
# Size: 19
# White: KataGo
# WhiteCommand: nc katago 80
# WhiteLabel: KataGo
# WhiteVersion: 1.10.0
# Xml: 0
#
#GAME   RES_B   RES_W   RES_R   ALT     DUP     LEN     TIME_B  TIME_W  CPU_B   CPU_W   ERR     ERR_MSG
0       B+143.5 B+146.5 ?       0       -       353     4.4     0.2     0       0.2     0
1       B+6.5   B+6.5   ?       1       -       68      0.8     0       0       0       0
```