### PR TITLE
Let program know what version of GoGui it's running in

### DIFF
--- a/doc/manual/xml/compatibility.xml
+++ b/doc/manual/xml/compatibility.xml
@@ -155,6 +155,15 @@ the program:
 
 <variablelist>
 <varlistentry>
+<term><command>gogui-version</command></term>
+<listitem>
+<para>
+Sent to program on startup so it can know what version of GoGui it's
+running in. Syntax will be like: "gogui-version 1.6.0".
+</para>
+</listitem>
+</varlistentry>
+<varlistentry>
 <term><command>gogui-action_forward</command></term>, <term><command>gogui-action_backward</command></term>
 <listitem>
 <para>

--- a/src/net/sf/gogui/gogui/GoGui.java
+++ b/src/net/sf/gogui/gogui/GoGui.java
@@ -2937,6 +2937,10 @@ ContextMenu.Listener, LiveGfx.Listener
                     Program.save(m_programs, false);
                     m_menuBar.setPrograms(m_programs, false);
                 }
+                // Send gogui version on startup
+                if (m_gtp.isSupported("gogui-version"))
+                    m_gtp.send("gogui-version " + Version.get());
+                // Get supported analyze commands
                 try
                 {
                     String programAnalyzeCommands


### PR DESCRIPTION
Hi,

Congratulations on 1.5/1.6 branch, GoGui has grown so much !

While working on the 1.4 branch I realized there is currently no way for the program to know what version of GoGui it's running in. This becomes problematic when a new GoGui feature is introduced, program has no way to know if it can take advantage of it or not.

I ended up adding a GoGui GTP extension in my branch:
If program implements `gogui-version` command, GoGui sends its version with it on startup.

It would be nice to have a way to do this that works across all GoGui versions (too bad this wasn't implemented from the start, can't do much about old versions now, but at least we could have it going forwards).

If there's a better way to do this please let me know, I'm happy to change my branch.